### PR TITLE
Adds Authorization via SNAC role for Vocabulary Editors

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Facades\DB;
 
 class User extends Authenticatable
 {
@@ -51,4 +52,16 @@ class User extends Authenticatable
     ];
 
     protected $table = 'appuser';
+
+    public function isVocabularyEditor() {
+        $userId = $this->id;
+        $vocabularyEditorPrivilegeLabel = 'Edit Vocabulary';
+        $roles = DB::table('appuser')->join('appuser_role_link', function($join) use ($userId) {
+            $join->on('appuser.id', '=', 'appuser_role_link.uid')->where('appuser.id', '=', $userId);
+        })->join('privilege_role_link','privilege_role_link.rid', '=', 'appuser_role_link.rid')->
+            join('privilege', function($join) use ($vocabularyEditorPrivilegeLabel) {
+            $join->on('privilege_role_link.pid', '=', 'privilege.id')->where('privilege.label', '=', $vocabularyEditorPrivilegeLabel);
+        })->select('appuser_role_link.rid')->get();
+        return $roles->count() > 0;
+    }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
+use App\Models\User;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -26,5 +27,8 @@ class AuthServiceProvider extends ServiceProvider
         $this->registerPolicies();
 
         //
+        Gate::define('edit-vocabulary',function(User $user) {
+            return $user->isVocabularyEditor();
+        });
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,11 +20,11 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
 Route::get('concepts',              'ConceptController@index');
-Route::post('concepts',             'ConceptController@store');
-Route::get('concepts/create',       'ConceptController@create');
+Route::post('concepts',             'ConceptController@store')->middleware('can:edit-vocabulary');
+Route::get('concepts/create',       'ConceptController@create')->middleware('can:edit-vocabulary');
 Route::get('concepts/search',       'ConceptController@search');
-Route::post('concepts/{concept}/add_term', 'ConceptController@addTerm');
-Route::get('concepts/{concept}',    'ConceptController@show');
+Route::post('concepts/{concept}/add_term', 'ConceptController@addTerm')->middleware('can:edit-vocabulary');
+Route::get('concepts/{concept}',    'ConceptController@show')->middleware('can:edit-vocabulary');
 Route::delete('concepts/{concept}', 'ConceptController@destroy');
 
 Route::post('logout/all', function () {


### PR DESCRIPTION
Using the SNAC tables that keep track of roles we are now validating
that the current user belongs to the role that has the correct
capability to edit Vocabulary. This was done implementing a new
permission Gate ('edit-vocabulary') that can be used in blade templates
as in other places where authorization is required.
