### PR TITLE
Add authorization logic to Concept show

### DIFF
--- a/app/Http/Controllers/ConceptController.php
+++ b/app/Http/Controllers/ConceptController.php
@@ -6,6 +6,7 @@ use App\Models\Concept;
 use App\Models\Term;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Auth;
 
 class ConceptController extends Controller
     {
@@ -126,7 +127,13 @@ class ConceptController extends Controller
                         ->with('sources')
                         ->findOrFail($concept_id);
 
-        return view('concepts.show', ['concept' => $concept]);
+        $isVocabularyEditor = false;
+        $user = Auth::user();
+        if (!Auth::guest()) {
+            $isVocabularyEditor = $user->isVocabularyEditor();
+        }
+
+        return view('concepts.show', ['concept' => $concept, 'isVocabularyEditor' => $isVocabularyEditor]);
     }
 
     /**

--- a/resources/js/components/ConceptForm.vue
+++ b/resources/js/components/ConceptForm.vue
@@ -59,7 +59,7 @@
                     <!-- TODO: Backend calls -->
                     <b-button variant="success" @click="addTerm()" v-show="editMode"><i class="fa fa-plus"></i> Add Term</b-button>
                     <b-button variant="secondary" @click="fetchConcept();toggleEditMode()" v-show="editMode">Cancel</b-button>
-                    <b-button variant="primary" @click="toggleEditMode()" v-show="!editMode"><i class="fa fa-edit"></i> Edit</b-button>
+                    <b-button variant="primary" @click="toggleEditMode()" v-if="isVocabularyEditor" v-show="!editMode"><i class="fa fa-edit"></i> Edit</b-button>
                 </div>
 
                 <div class="mt-3">
@@ -71,7 +71,7 @@
             </div>
         </div>
         <div class="mt-3">
-            <b-button v-b-modal.concept-relations-search variant="info"><i class="fa fa-plus"></i> Add Relationship</b-button>
+            <b-button v-if="isVocabularyEditor" v-b-modal.concept-relations-search variant="info"><i class="fa fa-plus"></i> Add Relationship</b-button>
         </div>
 
         <b-modal
@@ -157,7 +157,8 @@
             },
             sourcesProps: {
                 type: Array
-            }
+            },
+            canEditVocabulary: false,
         },
         data() {
             return {
@@ -188,7 +189,8 @@
                     { value:  400832, text: 'Relation'},
                 ],
                 cats: this.conceptProps.concept_categories,
-                selectedCategory: this.conceptProps.concept_categories[0].id
+                selectedCategory: this.conceptProps.concept_categories[0].id,
+                isVocabularyEditor: this.canEditVocabulary === "false" ? false : true
             }
         },
         computed: {

--- a/resources/js/components/ConceptSource.vue
+++ b/resources/js/components/ConceptSource.vue
@@ -57,7 +57,7 @@
       <p>{{url}}</p> <br/>
       <p>{{foundData}}</p> <br/>
       <p>{{note}}</p> <br/>
-      <b-button variant="primary" @click="toggleEditMode()" v-show="!editMode"><i class="fa fa-edit"></i> Edit Source</b-button>
+      <b-button variant="primary" @click="toggleEditMode()" v-if="isVocabularyEditor" v-show="!editMode"><i class="fa fa-edit"></i> Edit Source</b-button>
     </div>
   </div>
 </template>

--- a/resources/views/concepts/show.blade.php
+++ b/resources/views/concepts/show.blade.php
@@ -36,6 +36,7 @@
                     :concept-props="{{ $concept }}"
                     :term-props="{{ $concept->terms}}"
                     :sources-props="{{ $concept->sources}}"
+                    can-edit-vocabulary="{{ json_encode($isVocabularyEditor) }}"
                 >
                 </concept-form>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,7 +24,7 @@ Route::post('concepts',             'ConceptController@store')->middleware('can:
 Route::get('concepts/create',       'ConceptController@create')->middleware('can:edit-vocabulary');
 Route::get('concepts/search',       'ConceptController@search');
 Route::post('concepts/{concept}/add_term', 'ConceptController@addTerm')->middleware('can:edit-vocabulary');
-Route::get('concepts/{concept}',    'ConceptController@show')->middleware('can:edit-vocabulary');
+Route::get('concepts/{concept}',    'ConceptController@show');
 Route::delete('concepts/{concept}', 'ConceptController@destroy');
 
 Route::post('logout/all', function () {


### PR DESCRIPTION
Added via a property to the ConceptForm and ConceptSource components the
ability to distinguish if the component is being displayed for a
authorised user. The value is obtained from the Controller.

The middleware that allows creating, deleting and updating on the
backend is already specified for the relevant Controller methods.
