### PR TITLE
35298 api service layer

### DIFF
--- a/app/Http/Controllers/API/ConceptController.php
+++ b/app/Http/Controllers/API/ConceptController.php
@@ -2,10 +2,11 @@
 
 namespace App\Http\Controllers\API;
 
-use App\Models\Concept;
-use App\Models\Term;
-use App\Models\ConceptCategory;
 use App\Http\Controllers\Controller;
+use App\Http\Resources\ConceptResource;
+use App\Models\Concept;
+use App\Models\ConceptCategory;
+use App\Models\Term;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
@@ -14,11 +15,54 @@ class ConceptController extends Controller
     /**
      * Display a listing of the resource.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(Request $request)
     {
-        return Concept::with('conceptCategories')->get();
+        // Fetch the perPage parameter and set a maximum limit of 100
+        $perPage = $request->query('per_page', 15);
+        $perPage = min($perPage, 100);
+
+        // Validate that perPage is a positive integer
+        if (!is_numeric($perPage) || $perPage <= 0) {
+            $perPage = 15; // Fallback to default if invalid
+        }
+
+        // Fetch the sort_by and sort_order parameters with defaults
+        $sortBy = $request->query('sort_by', 'preferredTerm'); // Default to sorting by 'preferredTerm'
+        $sortOrder = $request->query('sort_order', 'asc'); // Default to ascending order
+
+        // Validate the sort_order to be either 'asc' or 'desc'
+        if (!in_array($sortOrder, ['asc', 'desc'])) {
+            $sortOrder = 'asc';
+        }
+
+        $items = Concept::with('terms', 'preferredTerm', 'conceptCategories')
+            ->select('concepts.*')
+            ->leftJoin('concept_categories', function ($join) {
+                $join->on('concepts.id', '=', 'concept_categories.concept_id');
+            })
+            ->leftJoin('vocabulary as category_vocabularies', function ($join) {
+                $join->on('concept_categories.category_id', '=', 'category_vocabularies.id');
+            })
+            ->leftJoin('terms as preferred_terms', function ($join) {
+                $join->on('concepts.id', '=', 'preferred_terms.concept_id')
+                    ->where('preferred_terms.preferred', true);
+            })
+            ->where(
+                'deprecated', '=', false
+            );
+
+        if ($sortBy === 'preferredTerm') {
+            $items->orderBy('preferred_terms.text'); // Order by the preferred term
+        } elseif ($sortBy === 'category') {
+            $items->orderBy('category_vocabularies.value'); // Order by the category name
+        } else {
+            $items->orderBy($sortBy, $sortOrder);
+        }
+
+        return ConceptResource::collection($items->paginate($perPage));
     }
 
     /**
@@ -31,7 +75,7 @@ class ConceptController extends Controller
     {
         $request->validate([
             'preferred_term' => 'required',
-            'category_id' => 'required_without:category'
+            'category_id' => 'required_without:category',
         ]);
 
         if (!isset($request['category_id'])) {
@@ -46,26 +90,26 @@ class ConceptController extends Controller
             $term = new Term;
             $term->text = $request['preferred_term'];
             $term->preferred = true;
-            if(!$concept->terms()->save($term)) {
+            if (!$concept->terms()->save($term)) {
                 throw new \Exception('Concept not created for term');
             }
             $conceptCategory = new ConceptCategory;
             $conceptCategory->concept_id = $concept->id;
             $conceptCategory->category_id = $request['category_id'];
-            if(!$conceptCategory->save()) {
+            if (!$conceptCategory->save()) {
                 throw new \Exception('Concept Category not created for Concept');
             }
             DB::commit();
             return response()->json([
                 "id" => $concept->id,
-                "termId" => $term->id
+                "termId" => $term->id,
             ]);
         } catch (\Exception $e) {
             DB::rollback();
             return response()->json([
                 "id" => false,
                 "error" => "Error creating new Concept",
-                "exception" => $e->getMessage()
+                "exception" => $e->getMessage(),
             ], 400);
         }
     }
@@ -110,7 +154,7 @@ class ConceptController extends Controller
             $concept->deprecated = !$concept->deprecated;
             $concept->save();
         }
-        return $concept->deprecated ? 'true' : 'false' ;
+        return $concept->deprecated ? 'true' : 'false';
     }
 
     /**
@@ -137,11 +181,11 @@ class ConceptController extends Controller
     {
         $request->validate([
             'term' => 'required',
-            'category' => 'required'
+            'category' => 'required',
         ]);
 
         if (isset($request['category'])) {
-             $category_id = config('cache.category_ids')[$request['category']] ?? null;
+            $category_id = config('cache.category_ids')[$request['category']] ?? null;
             $category = isset($category_id) ? $request['category'] : null;
         }
         $term = $_GET["term"];
@@ -150,10 +194,10 @@ class ConceptController extends Controller
             ->addSelect(DB::raw("true as match, 100 as score, '$category' as type"))
             ->leftJoin('terms', 'concepts.id', '=', 'terms.concept_id')
             ->leftJoin('concept_categories', 'concepts.id', '=', 'concept_categories.concept_id')
-                ->where([['text', 'ILIKE', $term]])
-                ->where('concept_categories.category_id', $category_id)
-                ->where('deprecated', false)
-                ->orderBy('preferred', 'desc');
+            ->where([['text', 'ILIKE', $term]])
+            ->where('concept_categories.category_id', $category_id)
+            ->where('deprecated', false)
+            ->orderBy('preferred', 'desc');
 
         return response()->json($terms->get());
     }

--- a/app/Http/Controllers/API/ConceptSourceController.php
+++ b/app/Http/Controllers/API/ConceptSourceController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\ConceptSourceResource;
 use App\Models\Concept;
 use App\Models\ConceptSource;
 use Illuminate\Http\Request;
@@ -12,11 +13,32 @@ class ConceptSourceController extends Controller
     /**
      * Display a listing of the resource.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(Request $request)
     {
-        return ConceptSource::all();
+        // Fetch the perPage parameter and set a maximum limit of 100
+        $perPage = $request->query('per_page', 15);
+        $perPage = min($perPage, 100); // Set a max limit of 100
+
+        // Validate that perPage is a positive integer
+        if (!is_numeric($perPage) || $perPage <= 0) {
+            $perPage = 15; // Fallback to default if invalid
+        }
+
+        // Fetch the sort_by and sort_order parameters with defaults
+        $sortBy = $request->query('sort_by', 'id'); // Default to sorting by 'id'
+        $sortOrder = $request->query('sort_order', 'asc'); // Default to ascending order
+
+        // Validate the sort_order to be either 'asc' or 'desc'
+        if (!in_array($sortOrder, ['asc', 'desc'])) {
+            $sortOrder = 'asc';
+        }
+
+        $items = ConceptSource::orderBy($sortBy, $sortOrder)->paginate($perPage);
+
+        return ConceptSourceResource::collection($items);
     }
 
     /**

--- a/app/Http/Controllers/API/ConceptSourceController.php
+++ b/app/Http/Controllers/API/ConceptSourceController.php
@@ -3,10 +3,9 @@
 namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
-
 use App\Models\Concept;
 use App\Models\ConceptSource;
+use Illuminate\Http\Request;
 
 class ConceptSourceController extends Controller
 {
@@ -17,7 +16,7 @@ class ConceptSourceController extends Controller
      */
     public function index()
     {
-        //
+        return ConceptSource::all();
     }
 
     /**
@@ -72,6 +71,6 @@ class ConceptSourceController extends Controller
     public function destroy($id)
     {
         $source = ConceptSource::findOrFail($id)->delete();
-        return response('Deleted'.$id, 204);
+        return response('Deleted' . $id, 204);
     }
 }

--- a/app/Http/Controllers/API/TermController.php
+++ b/app/Http/Controllers/API/TermController.php
@@ -3,19 +3,19 @@
 namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
+use App\Models\Term;
 use Illuminate\Http\Request;
 
-use App\Models\Concept;
-use App\Models\Term;
-
-class TermController extends Controller {
+class TermController extends Controller
+{
     /**
      * Display a listing of the resource.
      *
      * @return \Illuminate\Http\Response
      */
-    public function index() {
-        return $terms = Term::all();
+    public function index()
+    {
+        return Term::all();
     }
 
     /**
@@ -24,7 +24,8 @@ class TermController extends Controller {
      * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request) {
+    public function store(Request $request)
+    {
         return Term::create($request->all());
     }
 
@@ -34,7 +35,8 @@ class TermController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function show($id) {
+    public function show($id)
+    {
         return Term::findOrFail($id);
     }
 
@@ -45,7 +47,8 @@ class TermController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id) {
+    public function update(Request $request, $id)
+    {
         $term = Term::findOrFail($id);
         $term->update($request->all());
         return $term;
@@ -57,10 +60,10 @@ class TermController extends Controller {
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id) {
+    public function destroy($id)
+    {
         $term = Term::findOrFail($id)->delete();
         return response('Deleted', 204);
-
 
     }
 }

--- a/app/Http/Controllers/API/TermController.php
+++ b/app/Http/Controllers/API/TermController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\TermResource;
 use App\Models\Term;
 use Illuminate\Http\Request;
 
@@ -11,11 +12,32 @@ class TermController extends Controller
     /**
      * Display a listing of the resource.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(Request $request)
     {
-        return Term::all();
+        // Fetch the perPage parameter and set a maximum limit of 100
+        $perPage = $request->query('perPage', 15);
+        $perPage = min($perPage, 100); // Set a max limit of 100
+
+        // Validate that perPage is a positive integer
+        if (!is_numeric($perPage) || $perPage <= 0) {
+            $perPage = 15; // Fallback to default if invalid
+        }
+
+        // Fetch the sort_by and sort_order parameters with defaults
+        $sortBy = $request->query('sort_by', 'text'); // Default to sorting by 'text'
+        $sortOrder = $request->query('sort_order', 'asc'); // Default to ascending order
+
+        // Validate the sort_order to be either 'asc' or 'desc'
+        if (!in_array($sortOrder, ['asc', 'desc'])) {
+            $sortOrder = 'asc';
+        }
+
+        $items = Term::orderBy($sortBy, $sortOrder)->paginate($perPage);
+
+        return TermResource::collection($items);
     }
 
     /**

--- a/app/Http/Resources/ConceptResource.php
+++ b/app/Http/Resources/ConceptResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ConceptResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return parent::toArray($request);
+    }
+}

--- a/app/Http/Resources/ConceptSourceResource.php
+++ b/app/Http/Resources/ConceptSourceResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ConceptSourceResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return parent::toArray($request);
+    }
+}

--- a/app/Http/Resources/TermResource.php
+++ b/app/Http/Resources/TermResource.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TermResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return parent::toArray($request);
+    }
+}

--- a/app/Models/Concept.php
+++ b/app/Models/Concept.php
@@ -18,7 +18,7 @@ class Concept extends Model
      *
      * @var array
      */
-    protected $with = ["terms"];
+    protected $with = ["terms", "preferredTerm"];
 
     public function replacementOf()
     {
@@ -109,10 +109,8 @@ class Concept extends Model
         return $this->belongsToMany("App\Models\Vocabulary", "concept_categories", "concept_id", "category_id");
     }
 
-    // TODO: Make a preferredTerm function that returns correct term?
     public function preferredTerm()
     {
-        return $this->hasOne("App\Models\Term")->where("preferred", true)->first();
+        return $this->hasOne("App\Models\Term")->where("preferred", true);
     }
-
 }

--- a/app/Models/Term.php
+++ b/app/Models/Term.php
@@ -4,7 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 
-class Term extends Model {
+class Term extends Model
+{
 
     protected $fillable = [
         "text",
@@ -13,9 +14,8 @@ class Term extends Model {
     ];
     protected $hidden = ["created_at", "updated_at"];
 
-
-  public function concept() {
-    return $this->belongsTo("App\Models\Concept");
-  }
-
+    public function concept()
+    {
+        return $this->belongsTo("App\Models\Concept");
+    }
 }

--- a/resources/js/api/ConceptService.js
+++ b/resources/js/api/ConceptService.js
@@ -1,0 +1,43 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: `${process.env.MIX_APP_URL}/api/concepts`,
+});
+
+export default {
+  async listConcepts() {
+    try {
+      const { data } = await apiClient.get();
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+
+  async getConcept(conceptId) {
+    try {
+      const { data } = await apiClient.get(`/${conceptId}`);
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+
+  async createConcept(conceptData) {
+    try {
+      const { data } = await apiClient.post('', conceptData);
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+
+  async deleteConcept(conceptId) {
+    try {
+      const { data } = await apiClient.delete(`/${conceptId}`);
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+};

--- a/resources/js/api/ConceptService.js
+++ b/resources/js/api/ConceptService.js
@@ -5,9 +5,15 @@ const apiClient = axios.create({
 });
 
 export default {
-  async listConcepts() {
+  async listConcepts(perPage, sortBy, sortOrder) {
     try {
-      const { data } = await apiClient.get();
+      const { data } = await apiClient.get('', {
+        params: {
+          per_page: perPage,
+          sort_by: sortBy,
+          sort_order: sortOrder,
+        },
+      });
       return [null, data];
     } catch (error) {
       return [error];

--- a/resources/js/api/ConceptSourceService.js
+++ b/resources/js/api/ConceptSourceService.js
@@ -1,0 +1,55 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: `${process.env.MIX_APP_URL}/api/concept_sources`,
+});
+
+export default {
+  async listConceptSources() {
+    try {
+      const { data } = await apiClient.get();
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+
+  async getConceptSource(conceptSourceId) {
+    try {
+      const { data } = await apiClient.get(`/${conceptSourceId}`);
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+
+  async createConceptSource(conceptSourceData) {
+    try {
+      const { data } = await apiClient.post('', conceptSourceData);
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+
+  async updateConceptSource(conceptSourceId, conceptSourceData) {
+    try {
+      const { data } = await apiClient.post(
+        `/${conceptSourceId}`,
+        conceptSourceData,
+      );
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+
+  async deleteConceptSource(conceptSourceId) {
+    try {
+      const { data } = await apiClient.delete(`/${conceptSourceId}`);
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+};

--- a/resources/js/api/ConceptSourceService.js
+++ b/resources/js/api/ConceptSourceService.js
@@ -5,9 +5,15 @@ const apiClient = axios.create({
 });
 
 export default {
-  async listConceptSources() {
+  async listConceptSources(perPage, sortBy, sortOrder) {
     try {
-      const { data } = await apiClient.get();
+      const { data } = await apiClient.get({
+        params: {
+          per_page: perPage,
+          sort_by: sortBy,
+          sort_order: sortOrder,
+        },
+      });
       return [null, data];
     } catch (error) {
       return [error];

--- a/resources/js/api/TermService.js
+++ b/resources/js/api/TermService.js
@@ -1,0 +1,52 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: `${process.env.MIX_APP_URL}/api/terms`,
+});
+
+export default {
+  async listTerms() {
+    try {
+      const { data } = await apiClient.get();
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+
+  async getTerm(termId) {
+    try {
+      const { data } = await apiClient.get(`/${termId}`);
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+
+  async createTerm(termData) {
+    try {
+      const { data } = await apiClient.post('', termData);
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+
+  async updateTerm(termId, termData) {
+    try {
+      const { data } = await apiClient.patch(`/${termId}`, termData);
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+
+  async deleteTerm(termId) {
+    try {
+      const { data } = await apiClient.delete(`/${termId}`);
+      return [null, data];
+    } catch (error) {
+      return [error];
+    }
+  },
+};

--- a/resources/js/api/TermService.js
+++ b/resources/js/api/TermService.js
@@ -5,9 +5,15 @@ const apiClient = axios.create({
 });
 
 export default {
-  async listTerms() {
+  async listTerms(perPage, sortBy, sortOrder) {
     try {
-      const { data } = await apiClient.get();
+      const { data } = await apiClient.get({
+        params: {
+          perPage,
+          sort_by: sortBy,
+          sort_order: sortOrder,
+        },
+      });
       return [null, data];
     } catch (error) {
       return [error];

--- a/resources/js/api/index.js
+++ b/resources/js/api/index.js
@@ -1,0 +1,5 @@
+import ConceptService from './ConceptService';
+import ConceptSourceService from './ConceptSourceService';
+import TermService from './TermService';
+
+export { ConceptService, ConceptSourceService, TermService };

--- a/resources/js/components/Concept/Create.vue
+++ b/resources/js/components/Concept/Create.vue
@@ -55,6 +55,7 @@
 <script>
 import { BFormGroup, BButton, BFormInput, BFormSelect } from 'bootstrap-vue';
 import { categories } from '../../config/catgegories';
+import { ConceptService } from '../../api';
 
 export default {
   data() {
@@ -68,33 +69,22 @@ export default {
     };
   },
   methods: {
-    createConcept: function () {
+    async createConcept() {
       if (!this.canSave) {
         return;
       }
 
-      let data = {
+      const [error, concept] = await ConceptService.createConcept({
         preferred_term: this.preferredTerm,
         category_id: this.categoryId,
-      };
-      let vm = this;
-      axios
-        .post(`${this.baseURL}/api/concepts`, data)
-        .then(function (response) {
-          let result = response.data;
-          console.log(response);
-          if (!result.error && result.id) {
-            vm.conceptId = result.id;
-            vm.saved = true;
-            vm.redirectToConcept();
-          } else {
-            console.error('Error creating', result.error);
-            console.error('Exception', result.exception);
-          }
-        })
-        .catch(function (error) {
-          console.log(error);
-        });
+      });
+
+      if (error) console.error(error);
+      else {
+        this.conceptId = concept.id;
+        this.saved = true;
+        this.redirectToConcept();
+      }
     },
     redirectToConcept: function () {
       window.location.href = `/concepts/${this.conceptId}`;

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,9 +1,8 @@
 <?php
 
+use App\Models\Term;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-use App\Models\Concept;
-use App\Models\Term;
 
 /*
 |--------------------------------------------------------------------------
@@ -14,7 +13,7 @@ use App\Models\Term;
 | routes are loaded by the RouteServiceProvider within a group which
 | is assigned the "api" middleware group. Enjoy building your API!
 |
-*/
+ */
 
 Route::middleware('auth:api')->get('/user', function (Request $request) {
     return $request->user();
@@ -25,7 +24,9 @@ Route::get('concepts/reconcile', 'API\ConceptController@reconcile');
 
 Route::put('concepts/{id}/relate_concept', 'ConceptController@relateConcepts');
 Route::put('concepts/{id}/deprecate', 'API\ConceptController@deprecate');
-Route::apiResource('concepts', 'API\ConceptController');
+Route::apiResource('concepts', 'API\ConceptController')->except([
+    'update',
+]);
 
 Route::get('concepts_summary', function () {
     // Return only the preferred term
@@ -37,4 +38,3 @@ Route::get('concepts_summary', function () {
 Route::apiResource('concept_sources', 'API\ConceptSourceController');
 
 Route::apiResource('terms', 'API\TermController');
-Route::delete('terms/{id}/destroy', 'API\TermController@destroy');


### PR DESCRIPTION
**Link to Ticket:**  
https://app.shortcut.com/snac/story/35298/build-out-api-service-layer-for-frontend-components

**PR Summary:**  
This PR cleans up the api routes a bit, adds service objects representing the available actions for the Vue frontend, and implements pagination and sorting for the index routes in the backend controllers, fixes preferred term relationship in the concept model.

**Testing Instructions:**  
1. Concept creation still works
2. API actions in frontend components can be replaced with service calls similar to the createConcept method in `resources/js/components/Concept`

**Notes:**  
- Due to the preferred term fix and the addition of the preferred term as a relationship that is loaded by default in the concept model the vocabulary list at `/concepts` is now rendering incorrectly.
    - @jglass-st It would probably be a good idea to add a ticket to overhaul that index page to use the concept api that now has full Laravel pagination support.
