### PR TITLE
add alternate terms interface to create concept

### DIFF
--- a/app/Http/Requests/API/Concept/StoreRequest.php
+++ b/app/Http/Requests/API/Concept/StoreRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Requests\API\Concept;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'preferred_term' => 'required:string',
+            'category_id' => 'required',
+            'alternate_terms' => 'array',
+            'alternate_terms.*' => 'string',
+        ];
+    }
+
+    /**
+     * Handle a passed validation attempt.
+     */
+    protected function passedValidation(): void
+    {
+        // Get validated data
+        $validated = $this->validated();
+
+        // Build the terms array with the alternate terms
+        $terms = collect($validated['alternate_terms'] ?? [])
+            ->map(function ($term) {
+                return [
+                    'text' => $term,
+                    'preferred' => false,
+                ];
+            })
+            ->toArray();
+
+        // Add the preferred term to the terms array
+        $terms[] = [
+            'text' => $validated['preferred_term'],
+            'preferred' => true,
+        ];
+
+        // Add the newly structured terms array
+        $this->merge([
+            'terms' => $terms,
+        ]);
+
+        // Remove preferred term and alternate_terms
+        unset($this['preferred_term']);
+        unset($this['alternate_terms']);
+    }
+}

--- a/resources/js/components/Concept/Create.vue
+++ b/resources/js/components/Concept/Create.vue
@@ -96,6 +96,7 @@ export default {
       alternateTerms: [],
       conceptId: null,
       saved: false,
+      saving: false,
       categories,
       categoryId: null,
       baseURL: process.env.MIX_APP_URL,
@@ -108,6 +109,8 @@ export default {
       if (!this.canSave) {
         return;
       }
+
+      this.saving = true;
 
       const [error, concept] = await ConceptService.createConcept({
         preferred_term: this.preferredTerm,
@@ -168,6 +171,7 @@ export default {
     canSave() {
       return (
         !this.saved &&
+        !this.saving &&
         this.preferredTermState === true &&
         this.conceptCategoryState === true &&
         this.alternateTermsState === true

--- a/resources/js/components/Concept/Create.vue
+++ b/resources/js/components/Concept/Create.vue
@@ -34,26 +34,58 @@
         :state="conceptCategoryState"
       ></BFormSelect>
     </BFormGroup>
+
+    <template v-if="alternateTerms.length > 0">
+      <h3>Alternate Terms</h3>
+      <BInputGroup
+        class="mb-2"
+        v-for="(term, index) in alternateTerms"
+        :key="index"
+      >
+        <BFormInput
+          type="text"
+          v-model="alternateTerms[index]"
+          :id="`alternate-term-${index}`"
+          :state="alternateTermState(term)"
+        ></BFormInput>
+
+        <BInputGroupAppend>
+          <BButton
+            @click="removeAlternateTerm(index)"
+            class="btn btn-danger"
+            title="Delete"
+            ><i class="fa fa-trash"></i
+          ></BButton>
+        </BInputGroupAppend>
+
+        <BFormInvalidFeedback :id="`alternate-term-${index}`">
+          {{ alternateTermInvalid }}
+        </BFormInvalidFeedback>
+      </BInputGroup>
+    </template>
+
     <br />
     <BButton
-      v-show="!saved"
       @click="createConcept"
       :disabled="!canSave"
       variant="info"
-      title="Make Preferred"
+      title="Save"
       ><i class="fa fa-floppy-o"></i> Save</BButton
     >
-    <BButton>Add Term</BButton>
-    <div v-show="saved" class="mt-3">
-      <BButton variant="success" @click="redirectToConcept"
-        ><i class="fa fa-plus"></i> Manage Concept</BButton
-      >
-    </div>
+    <BButton @click="addAlternateTerm">Add Term</BButton>
   </div>
 </template>
 
 <script>
-import { BFormGroup, BButton, BFormInput, BFormSelect } from 'bootstrap-vue';
+import {
+  BFormGroup,
+  BButton,
+  BFormInput,
+  BFormSelect,
+  BInputGroup,
+  BInputGroupAppend,
+  BFormInvalidFeedback,
+} from 'bootstrap-vue';
 import { categories } from '../../config/catgegories';
 import { ConceptService } from '../../api';
 
@@ -61,11 +93,14 @@ export default {
   data() {
     return {
       preferredTerm: null,
+      alternateTerms: [],
       conceptId: null,
       saved: false,
       categories,
       categoryId: null,
       baseURL: process.env.MIX_APP_URL,
+      preferredTermInvalid: 'Preferred Term is required.',
+      alternateTermInvalid: 'Alternate Term cannot be empty.',
     };
   },
   methods: {
@@ -77,6 +112,7 @@ export default {
       const [error, concept] = await ConceptService.createConcept({
         preferred_term: this.preferredTerm,
         category_id: this.categoryId,
+        alternate_terms: this.alternateTerms,
       });
 
       if (error) console.error(error);
@@ -89,6 +125,19 @@ export default {
     redirectToConcept: function () {
       window.location.href = `/concepts/${this.conceptId}`;
     },
+    addAlternateTerm() {
+      this.alternateTerms.push(null);
+    },
+    removeAlternateTerm(index) {
+      this.alternateTerms.splice(index, 1);
+    },
+    alternateTermState(term) {
+      if (term === null) {
+        return null;
+      }
+
+      return term.length > 0;
+    },
   },
   computed: {
     preferredTermState() {
@@ -98,9 +147,6 @@ export default {
 
       return this.preferredTerm.length > 0;
     },
-    preferredTermInvalid() {
-      return 'Preferred Term is required.';
-    },
     conceptCategoryState() {
       if (this.categoryId === null) {
         return null;
@@ -109,6 +155,9 @@ export default {
       return this.categories.some(
         (category) => category.value === this.categoryId,
       );
+    },
+    alternateTermsState() {
+      return this.alternateTerms.every((term) => this.alternateTermState(term));
     },
     conceptCategoryInvalid() {
       const validCategories = this.categories
@@ -120,7 +169,8 @@ export default {
       return (
         !this.saved &&
         this.preferredTermState === true &&
-        this.conceptCategoryState === true
+        this.conceptCategoryState === true &&
+        this.alternateTermsState === true
       );
     },
   },
@@ -129,6 +179,9 @@ export default {
     BButton,
     BFormInput,
     BFormSelect,
+    BInputGroup,
+    BInputGroupAppend,
+    BFormInvalidFeedback,
   },
 };
 </script>


### PR DESCRIPTION
**Link to Ticket:**  
https://app.shortcut.com/snac/story/31419/add-a-new-vocabulary-concept

**PR Summary:**  
Adds alternate terms to create interface

**Testing Instructions:**  
1. Go to /concepts/create
2. Create a concept and add and remove alternate terms
3. Click save
4. Should be redirected to the new concept and see the assigned category and alternate terms that were entered

