### PR TITLE
refactor list component to use new api endpoint

### DIFF
--- a/app/Http/Controllers/API/ConceptController.php
+++ b/app/Http/Controllers/API/ConceptController.php
@@ -55,9 +55,9 @@ class ConceptController extends Controller
             );
 
         if ($sortBy === 'preferredTerm') {
-            $items->orderBy('preferred_terms.text'); // Order by the preferred term
+            $items->orderBy('preferred_terms.text', $sortOrder); // Order by the preferred term
         } elseif ($sortBy === 'category') {
-            $items->orderBy('category_vocabularies.value'); // Order by the category name
+            $items->orderBy('category_vocabularies.value', $sortOrder); // Order by the category name
         } else {
             $items->orderBy($sortBy, $sortOrder);
         }

--- a/app/Http/Controllers/ConceptController.php
+++ b/app/Http/Controllers/ConceptController.php
@@ -5,8 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\Concept;
 use App\Models\Term;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 class ConceptController extends Controller
 {
@@ -17,27 +17,6 @@ class ConceptController extends Controller
      */
     public function index(Request $request)
     {
-        if($request->ajax()) {
-            $perPage = intval($request['per_page']);
-            if ($perPage <= 0) {
-                $perPage = 10;
-            }
-            $sortBy = $request['sort_by'];
-            $sortDesc = $request['sort_desc'] == 'true' ? 'desc' : 'asc';
-            $concepts = Concept::leftJoin('concept_categories', function($join) {
-                $join->on('concepts.id', '=', 'concept_categories.concept_id');
-            })->leftJoin('vocabulary', function($join) {
-                $join->on('category_id', '=', 'vocabulary.id');
-            })->leftJoin('terms', function($join) {
-                $join->on('concepts.id', '=', 'terms.concept_id');
-                $join->on('preferred', '=', DB::raw("True"));
-            })->where(
-                'deprecated', '=', false
-            )->select('concepts.id as id', 'vocabulary.value as category', 'terms.text as preferred_term')
-                ->orderBy($sortBy, $sortDesc)->paginate($perPage);
-            return $concepts->toJson();
-        }
-
         $user = Auth::user();
         $isVocabularyEditor = false;
         if (!Auth::guest()) {
@@ -79,10 +58,10 @@ class ConceptController extends Controller
         //$term->save();
         $concept->terms()->save($term);
         //Savemany... Ref.
-        if($request->ajax()) {
+        if ($request->ajax()) {
             return [
                 "id" => $concept->id,
-                "termId" => $term->id
+                "termId" => $term->id,
             ];
         }
         return redirect('concepts')->with('status', 'Concept Created');
@@ -94,9 +73,9 @@ class ConceptController extends Controller
         $term = Term::create($request->all());
         $concept->terms()->save($term);
         //Savemany... Ref.
-        if($request->ajax()) {
+        if ($request->ajax()) {
             return [
-                "termId" => $term->id
+                "termId" => $term->id,
             ];
         }
         return redirect('concepts', $concept->id)->with('status', 'Term Created');
@@ -113,9 +92,9 @@ class ConceptController extends Controller
         $term->preferred = true;
         $term->save();
 
-        if($request->ajax()) {
+        if ($request->ajax()) {
             return [
-                "termId" => $term->id
+                "termId" => $term->id,
             ];
         }
         return redirect('concepts', $concept->id)->with('status', 'Term Marked Preferred');
@@ -130,11 +109,11 @@ class ConceptController extends Controller
     public function show($concept_id)
     {
         $concept = Concept::with('terms')
-                        ->with('broader')
-                        ->with('narrower')
-                        ->with('related')
-                        ->with('sources')
-                        ->findOrFail($concept_id);
+            ->with('broader')
+            ->with('narrower')
+            ->with('related')
+            ->with('sources')
+            ->findOrFail($concept_id);
 
         $isVocabularyEditor = false;
         $user = Auth::user();
@@ -144,23 +123,23 @@ class ConceptController extends Controller
 
         $relations = [];
 
-        if( count($concept->broader) ) {
+        if (count($concept->broader)) {
             $relations['Broader'] = [];
-            foreach($concept->broader as $broader) {
+            foreach ($concept->broader as $broader) {
                 $relations['Broader'][] = $broader->terms[0];
             }
         }
 
-        if( count($concept->narrower) ) {
+        if (count($concept->narrower)) {
             $relations['Narrower'] = [];
-            foreach($concept->narrower as $narrower) {
+            foreach ($concept->narrower as $narrower) {
                 $relations['Narrower'][] = $narrower->terms[0];
             }
         }
 
-        if( count($concept->related) ) {
+        if (count($concept->related)) {
             $relations['Related'] = [];
-            foreach($concept->related as $related) {
+            foreach ($concept->related as $related) {
                 $relations['Related'][] = $related->terms[0];
             }
         }
@@ -245,7 +224,6 @@ class ConceptController extends Controller
         return $terms->get();
     }
 
-
     /**
      * Relate Concepts
      *
@@ -273,6 +251,5 @@ class ConceptController extends Controller
 
         return $concept;
     }
-
 
 }

--- a/resources/js/api/ConceptService.js
+++ b/resources/js/api/ConceptService.js
@@ -5,13 +5,14 @@ const apiClient = axios.create({
 });
 
 export default {
-  async listConcepts(perPage, sortBy, sortOrder) {
+  async listConcepts(perPage, sortBy, sortOrder, page) {
     try {
       const { data } = await apiClient.get('', {
         params: {
           per_page: perPage,
           sort_by: sortBy,
           sort_order: sortOrder,
+          page,
         },
       });
       return [null, data];

--- a/resources/js/api/ConceptSourceService.js
+++ b/resources/js/api/ConceptSourceService.js
@@ -5,13 +5,14 @@ const apiClient = axios.create({
 });
 
 export default {
-  async listConceptSources(perPage, sortBy, sortOrder) {
+  async listConceptSources(perPage, sortBy, sortOrder, page) {
     try {
       const { data } = await apiClient.get({
         params: {
           per_page: perPage,
           sort_by: sortBy,
           sort_order: sortOrder,
+          page,
         },
       });
       return [null, data];

--- a/resources/js/api/TermService.js
+++ b/resources/js/api/TermService.js
@@ -5,13 +5,14 @@ const apiClient = axios.create({
 });
 
 export default {
-  async listTerms(perPage, sortBy, sortOrder) {
+  async listTerms(perPage, sortBy, sortOrder, page) {
     try {
       const { data } = await apiClient.get({
         params: {
           perPage,
           sort_by: sortBy,
           sort_order: sortOrder,
+          page,
         },
       });
       return [null, data];

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -33,15 +33,9 @@ import 'bootstrap-vue/dist/bootstrap-vue.css';
 // const files = require.context('./', true, /\.vue$/i)
 // files.keys().map(key => Vue.component(key.split('/').pop().split('.')[0], files(key).default))
 Vue.component('concept', require('./components/Concept.vue').default);
-Vue.component('concept-list', require('./components/ConceptList.vue').default);
-Vue.component(
-  'concept',
-  require('./components/Concept/Default.vue').default,
-  );
-Vue.component(
-  'concept-edit',
-  require('./components/Concept/Edit.vue').default,
-);
+Vue.component('concept-list', require('./components/Concept/List.vue').default);
+Vue.component('concept', require('./components/Concept/Default.vue').default);
+Vue.component('concept-edit', require('./components/Concept/Edit.vue').default);
 Vue.component(
   'concept-category',
   require('./components/ConceptCategory.vue').default,
@@ -62,13 +56,10 @@ Vue.component(
   'concept-search',
   require('./components/ConceptSearch.vue').default,
 );
-Vue.component(
-  'term-list',
-  require('./components/Term/List.vue').default
-);
+Vue.component('term-list', require('./components/Term/List.vue').default);
 Vue.component(
   'category-list',
-  require('./components/Category/List.vue').default
+  require('./components/Category/List.vue').default,
 );
 Vue.component('term-item', require('./components/TermItem.vue').default);
 Vue.component('cpf-form', require('./components/CPFForm.vue').default);

--- a/resources/js/components/Concept/List.vue
+++ b/resources/js/components/Concept/List.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <b-col sm="4" md="5" class="my-1">
-      <b-form-group
+    <BCol sm="4" md="5" class="my-1">
+      <BFormGroup
         label="Per page"
         label-cols-sm="6"
         label-cols-md="4"
@@ -11,26 +11,26 @@
         label-for="perPageSelect"
         class="mb-0"
       >
-        <b-form-select
+        <BFormSelect
           v-model="perPage"
           id="perPageSelect"
           size="sm"
           :options="pageOptions"
-        ></b-form-select>
-      </b-form-group>
-    </b-col>
+        ></BFormSelect>
+      </BFormGroup>
+    </BCol>
 
-    <b-col sm="7" md="6" class="my-1">
-      <b-pagination
+    <BCol sm="7" md="6" class="my-1">
+      <BPagination
         v-model="currentPage"
         :total-rows="totalRows"
         :per-page="perPage"
         align="fill"
         size="sm"
         class="my-0"
-      ></b-pagination>
-    </b-col>
-    <b-table
+      ></BPagination>
+    </BCol>
+    <BTable
       show-empty
       small
       stacked="md"
@@ -45,38 +45,51 @@
       :sort-desc.sync="sortDesc"
     >
       <template v-slot:cell(preferredTerm)="row">
-        <b-link :href="row.item.link">{{ row.item.preferredTerm }}</b-link>
+        <BLink :href="row.item.link">{{ row.item.preferredTerm }}</BLink>
       </template>
 
       <template v-slot:cell(actions)="row">
-        <b-button
+        <BButton
           size="sm"
           @click="info(row.item, row.index, $event.target)"
           class="mr-1"
         >
           Info modal
-        </b-button>
-        <b-button size="sm" @click="row.toggleDetails">
+        </BButton>
+        <BButton size="sm" @click="row.toggleDetails">
           {{ row.detailsShowing ? 'Hide' : 'Show' }} Details
-        </b-button>
+        </BButton>
       </template>
 
       <template v-slot:bottom-row="row"> </template>
 
       <template v-slot:row-details="row">
-        <b-card>
+        <BCard>
           <ul>
             <li v-for="(value, key) in row.item" :key="key">
               {{ key }}: {{ value }}
             </li>
           </ul>
-        </b-card>
+        </BCard>
       </template>
-    </b-table>
+    </BTable>
   </div>
 </template>
 
 <script>
+import {
+  BButton,
+  BCard,
+  BCol,
+  BFormGroup,
+  BFormSelect,
+  BLink,
+  BPagination,
+  BTable,
+} from 'bootstrap-vue';
+import { ConceptService } from '../../api';
+import { sortBy } from 'lodash';
+
 export default {
   data: function () {
     return {
@@ -90,44 +103,70 @@ export default {
         { key: 'preferredTerm', sortable: true },
         { key: 'category', sortable: true },
       ],
-      concepts: [{ key: 'hi', value: 10 }],
+      concepts: [],
       pageOptions: [5, 10, 15],
       currentPage: 1,
-      perPage: 14,
+      perPage: 15,
       totalRows: 1,
-      baseURL: process.env.MIX_APP_URL,
+      loading: true,
     };
   },
-  mounted() {
-    this.getConcepts();
+  computed: {
+    sortOrder() {
+      return this.sortDesc ? 'asc' : 'desc';
+    },
+  },
+  watch: {
+    perPage(val) {
+      this.getConcepts();
+    },
+    sortBy(val) {
+      this.getConcepts();
+    },
+    sortOrder(val) {
+      this.getConcepts();
+    },
+    currentPage(val) {
+      this.getConcepts();
+    },
   },
   methods: {
-    getConcepts: function () {
-      const toSnakeCase = (str) =>
-        str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
-
-      const promise = axios.get(
-        `?page=${this.currentPage}&per_page=${this.perPage}&sort_by=${toSnakeCase(this.sortBy)}&sort_desc=${this.sortDesc}`,
+    async getConcepts() {
+      const [error, concepts] = await ConceptService.listConcepts(
+        this.perPage,
+        this.sortBy,
+        this.sortOrder,
+        this.currentPage,
       );
 
-      return promise.then((response) => {
-        console.log(response);
-        let concepts = response.data.data;
-        let concept_result = concepts.map((concept) => {
+      let conceptData = [];
+
+      if (error) console.error(error);
+      else {
+        this.totalRows = concepts.meta.total;
+        conceptData = concepts.data.map((concept) => {
           return {
             id: concept.id,
             link: `${this.baseURL}/concepts/${concept.id}`,
             preferredTerm: concept.preferred_term.text,
-            category: concept.category,
+            category: concept.concept_categories[0].value,
           };
         });
-        this.totalRows = response.data.total;
-        this.concepts = concept_result;
-        return concept_result || [];
-      });
+        this.loading = false;
+      }
+
+      return conceptData;
     },
+  },
+  components: {
+    BCol,
+    BFormGroup,
+    BFormSelect,
+    BPagination,
+    BTable,
+    BLink,
+    BButton,
+    BCard,
   },
 };
 </script>
-
-<style scoped></style>

--- a/resources/js/components/Concept/List.vue
+++ b/resources/js/components/Concept/List.vue
@@ -98,7 +98,7 @@ export default {
         name: 'flip-list',
       },
       sortBy: 'preferredTerm',
-      sortDesc: false,
+      sortDesc: true,
       fields: [
         { key: 'preferredTerm', sortable: true },
         { key: 'category', sortable: true },


### PR DESCRIPTION
**Link to Ticket:**  
https://app.shortcut.com/snac/story/35357/update-concepts-index-page-to-use-new-laravel-pagination

**PR Summary:**  
Updates the concepts list component to use the API index endpoint

**Testing Instructions:**  
1. Go to /concepts
2. Should see a list of concepts with adjustable pagination amounts, pagination, and ordering

**Notes:**  
- Ordering by category still works strangely
