### PR TITLE
Fix asset compilation during deployment

### DIFF
--- a/.github/workflows/deploy_workflow.yml
+++ b/.github/workflows/deploy_workflow.yml
@@ -48,10 +48,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Composer install
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
-      - name: NPM Build
+      - name: NPM Install
         uses: actions/setup-node@v3
         with:
           node-version: 10.24.1
+      - name: NPM Setup
         run: |
           npm install
           npm run dev
@@ -71,10 +72,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Composer install
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
-      - name: NPM Build
+      - name: NPM Install
         uses: actions/setup-node@v3
         with:
           node-version: 10.24.1
+      - name: NPM Setup
         run: |
           npm install
           npm run dev

--- a/.github/workflows/deploy_workflow.yml
+++ b/.github/workflows/deploy_workflow.yml
@@ -38,52 +38,19 @@ jobs:
         env:
           DB_PORT: 5432
         run: vendor/bin/phpunit
-  build-js-production:
-    name: Build JavaScript/CSS for PRODUCTION Server
-    runs-on: ubuntu-latest
+  deploy-production:
+    name: Deploy Project to PRODUCTION Server
+    runs-on: self-hosted
     needs: app-tests
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
-      - name: NPM Build
-        run: |
-          npm install
-          npm run prod
-      - name: Put built assets in Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: assets
-          path: public
-  build-js-staging:
-    name: Build JavaScript/CSS for STAGING Server
-    runs-on: ubuntu-latest
-    needs: app-tests
-    if: github.ref == 'refs/heads/development'
-    steps:
-      - uses: actions/checkout@v4
+      - name: Composer install
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
       - name: NPM Build
         run: |
           npm install
           npm run dev
-      - name: Put built assets in Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: assets
-          path: public
-  deploy-production:
-    name: Deploy Project to PRODUCTION Server
-    runs-on: self-hosted
-    needs: [build-js-production, app-tests]
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Fetch built assets from Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: assets
-          path: public
-      - name: Composer install
-        run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
       - name: Deploy to Prod
         uses: deployphp/action@v1
         with:
@@ -94,17 +61,16 @@ jobs:
   deploy-development:
     name: Deploy Project to DEVELOPMENT Server
     runs-on: self-hosted
-    needs: [build-js-staging, app-tests]
-    if: github.ref == 'refs/heads/development'
+    needs: app-tests
+    if: github.ref == 'refs/heads/jnm/laravel-deploy'
     steps:
       - uses: actions/checkout@v4
-      - name: Fetch built assets from Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: assets
-          path: public
       - name: Composer install
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+      - name: NPM Build
+        run: |
+          npm install
+          npm run dev
       - name: Deploy to Dev
         uses: deployphp/action@v1
         with:

--- a/.github/workflows/deploy_workflow.yml
+++ b/.github/workflows/deploy_workflow.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Composer install
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
       - name: NPM Build
+        uses: actions/setup-node@v3
+        with:
+          node-version: 10.24.1
         run: |
           npm install
           npm run dev
@@ -69,6 +72,9 @@ jobs:
       - name: Composer install
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
       - name: NPM Build
+        uses: actions/setup-node@v3
+        with:
+          node-version: 10.24.1
         run: |
           npm install
           npm run dev

--- a/.github/workflows/deploy_workflow.yml
+++ b/.github/workflows/deploy_workflow.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - development
       - master
-      - jnm/laravel-deploy
 
 jobs:
   app-tests:
@@ -59,7 +58,7 @@ jobs:
     name: Deploy Project to DEVELOPMENT Server
     runs-on: self-hosted
     needs: app-tests
-    if: github.ref == 'refs/heads/jnm/laravel-deploy'
+    if: github.ref == 'refs/heads/development'
     steps:
       - uses: actions/checkout@v4
       - name: Composer install

--- a/.github/workflows/deploy_workflow.yml
+++ b/.github/workflows/deploy_workflow.yml
@@ -51,7 +51,7 @@ jobs:
       - name: NPM Install
         uses: actions/setup-node@v3
         with:
-          node-version: 10.24.1
+          node-version: 12.14
       - name: NPM Setup
         run: |
           npm install
@@ -75,7 +75,7 @@ jobs:
       - name: NPM Install
         uses: actions/setup-node@v3
         with:
-          node-version: 10.24.1
+          node-version: 12.14
       - name: NPM Setup
         run: |
           npm install

--- a/.github/workflows/deploy_workflow.yml
+++ b/.github/workflows/deploy_workflow.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - development
       - master
+      - jnm/laravel-deploy
 
 jobs:
   app-tests:

--- a/.github/workflows/deploy_workflow.yml
+++ b/.github/workflows/deploy_workflow.yml
@@ -48,14 +48,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Composer install
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
-      - name: NPM Install
-        uses: actions/setup-node@v3
-        with:
-          node-version: 12.14
-      - name: NPM Setup
-        run: |
-          npm install
-          npm run dev
       - name: Deploy to Prod
         uses: deployphp/action@v1
         with:
@@ -72,14 +64,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Composer install
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
-      - name: NPM Install
-        uses: actions/setup-node@v3
-        with:
-          node-version: 12.14
-      - name: NPM Setup
-        run: |
-          npm install
-          npm run dev
       - name: Deploy to Dev
         uses: deployphp/action@v1
         with:

--- a/deploy.php
+++ b/deploy.php
@@ -43,6 +43,7 @@ task('build', function() {
     if (input()->hasArgument('stage')) {
         $stage = input()->getArgument('stage');
     }
+    cd('{{release_or_current_path}}');
     run("npm ci && npm run $stage");
 });
 

--- a/deploy.php
+++ b/deploy.php
@@ -39,6 +39,7 @@ task('deploy:secrets', function () {
 });
 
 task('build', function() {
+    cd('{{release_or_current_path}}');
     run('npm install && npm run production');
 });
 

--- a/deploy.php
+++ b/deploy.php
@@ -38,7 +38,9 @@ task('deploy:secrets', function () {
     upload('.env', get('deploy_path') . '/shared');
 });
 
-task('build', 'npm install && npm run production');
+task('build', function() {
+    run('npm install && npm run production');
+});
 
 host('snaccooperative.org')
   ->set('hostname', 'snaccooperative.org')

--- a/deploy.php
+++ b/deploy.php
@@ -40,7 +40,7 @@ task('deploy:secrets', function () {
 
 task('build', function() {
     cd('{{release_or_current_path}}');
-    run('npm install && npm run production');
+    run('nvm use 12.14 && npm install && npm run production');
 });
 
 host('snaccooperative.org')

--- a/deploy.php
+++ b/deploy.php
@@ -44,7 +44,7 @@ task('build', function() {
         $stage = input()->getArgument('stage');
     }
     cd('{{release_or_current_path}}');
-    run("npm ci && npm run $stage");
+    run("npm install && npm run $stage");
 });
 
 host('snaccooperative.org')

--- a/deploy.php
+++ b/deploy.php
@@ -38,6 +38,14 @@ task('deploy:secrets', function () {
     upload('.env', get('deploy_path') . '/shared');
 });
 
+task('build', function() {
+    $stage = null;
+    if (input()->hasArgument('stage')) {
+        $stage = input()->getArgument('stage');
+    }
+    run("npm ci && npm run $stage");
+});
+
 host('snaccooperative.org')
   ->set('hostname', 'snaccooperative.org')
   ->set('labels', ['env' => 'production', 'stage' => 'production'])
@@ -68,4 +76,5 @@ task('deploy', [
     'artisan:queue:restart',
     'deploy:symlink',
     'deploy:cleanup',
+    'build'
 ]);

--- a/deploy.php
+++ b/deploy.php
@@ -38,14 +38,7 @@ task('deploy:secrets', function () {
     upload('.env', get('deploy_path') . '/shared');
 });
 
-task('build', function() {
-    $stage = null;
-    if (input()->hasArgument('stage')) {
-        $stage = input()->getArgument('stage');
-    }
-    cd('{{release_or_current_path}}');
-    run("npm install && npm run $stage");
-});
+task('build', 'npm install && npm run production');
 
 host('snaccooperative.org')
   ->set('hostname', 'snaccooperative.org')


### PR DESCRIPTION
If merged, this PR will:

* Remove the asset compilation and artifact storage steps from the GitHub Actions workflow
* Set up asset compilation as a custom task in the `deploy.php` file used by Deployer

This has been tested throughly. If you log into snac-dev now and go to `/lv2/snac-laravel/current/public`, you'll see the compiled CSS and JS files.