### PR TITLE
Remove base URL settings that point to MIX_APP_URL

### DIFF
--- a/resources/js/api/ConceptService.js
+++ b/resources/js/api/ConceptService.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-  baseURL: `${process.env.MIX_APP_URL}/api/concepts`,
+  baseURL: `api/concepts`,
 });
 
 export default {

--- a/resources/js/api/ConceptSourceService.js
+++ b/resources/js/api/ConceptSourceService.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-  baseURL: `${process.env.MIX_APP_URL}/api/concept_sources`,
+  baseURL: `api/concept_sources`,
 });
 
 export default {

--- a/resources/js/api/TermService.js
+++ b/resources/js/api/TermService.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-  baseURL: `${process.env.MIX_APP_URL}/api/terms`,
+  baseURL: `api/terms`,
 });
 
 export default {

--- a/resources/js/components/CPFForm.vue
+++ b/resources/js/components/CPFForm.vue
@@ -655,7 +655,7 @@ export default {
       propertyEditMode: true,
       categories,
       isVocabularyEditor: this.canEditVocabulary === true,
-      baseURL: process.env.MIX_APP_URL,
+      baseURL: '',
     };
   },
   computed: {

--- a/resources/js/components/Concept/Create.vue
+++ b/resources/js/components/Concept/Create.vue
@@ -99,7 +99,7 @@ export default {
       saving: false,
       categories,
       categoryId: null,
-      baseURL: process.env.MIX_APP_URL,
+      baseURL: '',
       preferredTermInvalid: 'Preferred Term is required.',
       alternateTermInvalid: 'Alternate Term cannot be empty.',
     };

--- a/resources/js/components/Concept/Default.vue
+++ b/resources/js/components/Concept/Default.vue
@@ -132,7 +132,7 @@ export default {
       categories,
       cats: this.conceptProps.concept_categories,
       isVocabularyEditor: this.canEditVocabulary !== 'false',
-      baseURL: process.env.MIX_APP_URL,
+      baseURL: '',
       devFeatures: process.env.MIX_INCLUDE_DEVELOPMENT_FEATURES == 'true',
     };
   },

--- a/resources/js/components/Concept/Edit.vue
+++ b/resources/js/components/Concept/Edit.vue
@@ -285,7 +285,7 @@ export default {
       cats: this.conceptProps.concept_categories,
       selectedCategory: this.conceptProps.concept_categories[0].id,
       isVocabularyEditor: this.canEditVocabulary !== 'false',
-      baseURL: process.env.MIX_APP_URL,
+      baseURL: '',
       devFeatures: process.env.MIX_INCLUDE_DEVELOPMENT_FEATURES == 'true',
     };
   },

--- a/resources/js/components/Concept/List.vue
+++ b/resources/js/components/Concept/List.vue
@@ -108,7 +108,7 @@ export default {
       currentPage: 1,
       perPage: 15,
       totalRows: 1,
-      baseURL: process.env.MIX_APP_URL,
+      baseURL: '',
     };
   },
   computed: {

--- a/resources/js/components/Source/Default.vue
+++ b/resources/js/components/Source/Default.vue
@@ -53,7 +53,7 @@ export default {
       editMode: false,
       isVocabularyEditor: this.canEditVocabulary === true,
       index: this.sourceIndex,
-      baseURL: process.env.MIX_APP_URL,
+      baseURL: '',
       state: state,
     };
   },

--- a/resources/js/components/Source/Edit.vue
+++ b/resources/js/components/Source/Edit.vue
@@ -86,7 +86,7 @@ export default {
       note: null,
       isVocabularyEditor: this.canEditVocabulary === true,
       index: this.sourceIndex,
-      baseURL: process.env.MIX_APP_URL,
+      baseURL: '',
     };
   },
   methods: {


### PR DESCRIPTION
If merged, this PR will:

- Remove base URL settings that point to the environment variable `MIX_APP_URL`

Calls to a non-existent `MIX_APP_URL` are causing URLs to include an invalid `undefined` token, which leads to a 404. Merging this should fix that issue.