### PR TITLE
Base64 decode the ENV file string

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -39,7 +39,7 @@ task('deploy:secrets', function () {
         $stage = input()->getArgument('stage');
     }
     $env_file = ($stage == 'production') ? 'ENV_PROD' : 'ENV_DEV';
-    file_put_contents(__DIR__ . '/.env', getenv($env_file));
+    file_put_contents(__DIR__ . '/.env', base64_decode(getenv($env_file)));
     upload('.env', get('deploy_path') . '/shared');
 });
 


### PR DESCRIPTION
I forgot that the ENV file is being stored as a base64-encoded string and needs to be decoded before it's written to disk as the `.env` file.