### PR TITLE
Final adjustment to loading `.env` file from environment variable

### DIFF
--- a/.github/workflows/deploy_workflow.yml
+++ b/.github/workflows/deploy_workflow.yml
@@ -51,6 +51,10 @@ jobs:
         uses: deployphp/action@v1
         with:
           dep: deploy stage=production
+          options:
+            keep_releases: 10
+          env:
+            ENV_FILE: ${{ secrets.ENV_PROD }}
           private-key: ${{ secrets.SSH_PRIVATE_KEY_PROD }}
           skip-ssh-setup: true
           verbosity: -vvv
@@ -67,6 +71,10 @@ jobs:
         uses: deployphp/action@v1
         with:
           dep: deploy stage=development
+          options:
+            keep_releases: 10
+          env:
+            ENV_FILE: ${{ secrets.ENV_DEV }}
           private-key: ${{ secrets.SSH_PRIVATE_KEY_DEV }}
           skip-ssh-setup: true
           verbosity: -vvv

--- a/deploy.php
+++ b/deploy.php
@@ -34,12 +34,7 @@ add('rsync', [
 ]);
 
 task('deploy:secrets', function () {
-    $stage = null;
-    if (input()->hasArgument('stage')) {
-        $stage = input()->getArgument('stage');
-    }
-    $env_file = ($stage == 'production') ? 'ENV_PROD' : 'ENV_DEV';
-    file_put_contents(__DIR__ . '/.env', base64_decode(getenv($env_file)));
+    file_put_contents(__DIR__ . '/.env', base64_decode(getenv('ENV_FILE')));
     upload(__DIR__ . '/.env', get('deploy_path') . '/shared');
 });
 

--- a/deploy.php
+++ b/deploy.php
@@ -40,7 +40,7 @@ task('deploy:secrets', function () {
     }
     $env_file = ($stage == 'production') ? 'ENV_PROD' : 'ENV_DEV';
     file_put_contents(__DIR__ . '/.env', base64_decode(getenv($env_file)));
-    upload('.env', get('deploy_path') . '/shared');
+    upload(__DIR__ . '/.env', get('deploy_path') . '/shared');
 });
 
 task('build', function() {


### PR DESCRIPTION
If merged, this PR will:

* Remove the stage and ENV var name code from the `deploy.php` script
* Set the `ENV_FILE` variable to the current stage's ENV file content using GitHub Actions secrets
* Set the proper path that the ENV file should be uploaded to when it is created
* Tell Deployer to only keep the 10 most-recent deploys