### PR TITLE
[#31418] Concept Categories

### DIFF
--- a/resources/js/components/Category/Editable.vue
+++ b/resources/js/components/Category/Editable.vue
@@ -4,7 +4,6 @@
       <div
         v-if="originalId"
         class="category-item custom-select"
-        :class="{ 'font-weight-bold': isPrimary }"
       >
         {{ selectedValue }}
       </div>
@@ -77,10 +76,6 @@ export default {
     categoryId: {
       type: Number,
       default: null,
-    },
-    isPrimary: {
-      type: Boolean,
-      default: false,
     },
     categoryValue: {
       type: String,

--- a/resources/js/components/Concept/Default.vue
+++ b/resources/js/components/Concept/Default.vue
@@ -131,7 +131,6 @@
             <p class="mb-2">
               <span
                 v-if="!getEditMode() || !canEditVocabulary"
-                :class="{ 'font-weight-bold': index === 0 }"
               >
                 {{ cat.value }}
               </span>
@@ -140,7 +139,6 @@
                 :category-id="cat.id"
                 :category-value="cat.value"
                 :category-index="index"
-                :is-primary="0 === index"
                 :selected-categories="selectedCategories"
                 @save-category="saveCategory"
                 @delete-category="deleteCategory"

--- a/resources/views/concepts/show.blade.php
+++ b/resources/views/concepts/show.blade.php
@@ -8,12 +8,7 @@
     @endif
 
     <ol class="breadcrumb">
-        {{-- TODO:  Rename Occupation Terms with dynamic concept category or categories   --}}
         <li class="breadcrumb-item"><a href="/concepts">Concepts</a></li>
-
-        @if (!empty($concept->conceptCategories) and (count($concept->conceptCategories) > 0))
-            <li class="breadcrumb-item active">{{ $concept->conceptCategories[0]['value']}} Terms</li>
-        @endif
     </ol>
 
     @if (false) #permissions.EditResources


### PR DESCRIPTION
# Summary

This PR makes a few slight UI adjustments to the display of Categories. The functionality of the ticket was handled in another branch and is already in `development`.

## Issues

* [#31418](https://app.shortcut.com/snac/story/31418/set-category-for-vocabulary-concept)

## Testing Instructions

1. Visit a concept vocabulary term page
2. Note the removal of the Category Breadcrumb
3. All categories should look the same, appearance-wise
4. Go into Edit mode
5. Add or remove existing categories
6. Exit Edit mode