### PR TITLE
Handle zero categories on /concepts browse page

### DIFF
--- a/resources/js/components/Concept/List.vue
+++ b/resources/js/components/Concept/List.vue
@@ -135,7 +135,7 @@ export default {
             id: concept.id,
             link: `${this.baseURL}/concepts/${concept.id}`,
             preferredTerm: concept.preferred_term.text,
-            category: concept.concept_categories[0].value,
+            category: concept.concept_categories[0]?.value,
           };
         });
         this.loading = false;


### PR DESCRIPTION
**PR Summary:**
Temporary safety check for missing categories, per user request. 

Adds a optional chaining/null check on the Concept Browse categories. This allows the browse page to display even if a concept is inadvertently without a category.